### PR TITLE
Create kids calculator UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,45 +7,21 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Kids Calculator',
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(title: 'Kids Calculator'),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
 
   final String title;
 
@@ -54,69 +30,147 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
+  String _display = '0';
+  double? _firstOperand;
+  String _operator = '';
+  bool _shouldClear = false;
 
-  void _incrementCounter() {
+  void _onDigit(String digit) {
     setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
+      if (_shouldClear || _display == '0') {
+        _display = digit;
+        _shouldClear = false;
+      } else {
+        _display += digit;
+      }
     });
+  }
+
+  void _onOperator(String op) {
+    _firstOperand = double.tryParse(_display);
+    _operator = op;
+    _shouldClear = true;
+  }
+  void _calculate() {
+    if (_firstOperand == null || _operator.isEmpty) return;
+    final secondOperand = double.tryParse(_display) ?? 0;
+    double result = 0;
+    switch (_operator) {
+      case '+':
+        result = (_firstOperand ?? 0) + secondOperand;
+        break;
+      case '-':
+        result = (_firstOperand ?? 0) - secondOperand;
+        break;
+      case '×':
+        result = (_firstOperand ?? 0) * secondOperand;
+        break;
+      case '÷':
+        result = secondOperand == 0 ? 0 : (_firstOperand ?? 0) / secondOperand;
+        break;
+    }
+    setState(() {
+      _display = result.toString().replaceAll(RegExp(r'\.0\$'), '');
+      _firstOperand = null;
+      _operator = '';
+      _shouldClear = true;
+    });
+  }
+
+  void _clear() {
+    setState(() {
+      _display = '0';
+      _firstOperand = null;
+      _operator = '';
+      _shouldClear = false;
+    });
+  }
+
+  Widget _buildButton(String text,
+      {Color? color, required VoidCallback onPressed}) {
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.all(4.0),
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: color ?? Colors.blue.shade100,
+            padding: const EdgeInsets.symmetric(vertical: 20),
+          ),
+          onPressed: onPressed,
+          child: Text(text, style: const TextStyle(fontSize: 24)),
+        ),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+      appBar: AppBar(title: Text(widget.title)),
+      body: Column(
+        children: [
+          Expanded(
+            child: Container(
+              alignment: Alignment.bottomRight,
+              padding: const EdgeInsets.all(16.0),
+              color: Colors.white,
+              child: Text(
+                _display,
+                style: const TextStyle(
+                  fontSize: 48,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
             ),
-          ],
-        ),
+          ),
+          Column(
+            children: [
+              Row(
+                children: [
+                  _buildButton('7', onPressed: () => _onDigit('7')),
+                  _buildButton('8', onPressed: () => _onDigit('8')),
+                  _buildButton('9', onPressed: () => _onDigit('9')),
+                  _buildButton('÷',
+                      color: Colors.orange.shade200,
+                      onPressed: () => _onOperator('÷')),
+                ],
+              ),
+              Row(
+                children: [
+                  _buildButton('4', onPressed: () => _onDigit('4')),
+                  _buildButton('5', onPressed: () => _onDigit('5')),
+                  _buildButton('6', onPressed: () => _onDigit('6')),
+                  _buildButton('×',
+                      color: Colors.orange.shade200,
+                      onPressed: () => _onOperator('×')),
+                ],
+              ),
+              Row(
+                children: [
+                  _buildButton('1', onPressed: () => _onDigit('1')),
+                  _buildButton('2', onPressed: () => _onDigit('2')),
+                  _buildButton('3', onPressed: () => _onDigit('3')),
+                  _buildButton('-',
+                      color: Colors.orange.shade200,
+                      onPressed: () => _onOperator('-')),
+                ],
+              ),
+              Row(
+                children: [
+                  _buildButton('0', onPressed: () => _onDigit('0')),
+                  _buildButton('C',
+                      color: Colors.red.shade200, onPressed: _clear),
+                  _buildButton('=',
+                      color: Colors.green.shade200, onPressed: _calculate),
+                  _buildButton('+',
+                      color: Colors.orange.shade200,
+                      onPressed: () => _onOperator('+')),
+                ],
+              ),
+            ],
+          ),
+        ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:calc_kids/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Pressing a digit updates display', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+    await tester.tap(find.text('1'));
     await tester.pump();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
     expect(find.text('1'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- replace default counter app with a simple kids calculator supporting the four operations
- add basic widget test validating digit input
- fix regexp escaping

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d31e3d5f0832097e76eb27fc31f7e